### PR TITLE
check grpcClient before ding to avoid unexpected error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-hostie",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Puppet Hostie for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-hostie",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Puppet Hostie for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-hostie",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Puppet Hostie for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-hostie",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Puppet Hostie for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -467,7 +467,7 @@ export class PuppetHostie extends Puppet {
 
     if (!this.grpcClient) {
       log.info('PuppetHostie', `ding() Skip ding since grpcClient is not connected.`)
-      return;
+      return
     }
 
     this.grpcClient.ding(

--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -465,7 +465,12 @@ export class PuppetHostie extends Puppet {
     const request = new DingRequest()
     request.setData(data || '')
 
-    this.grpcClient!.ding(
+    if (!this.grpcClient) {
+      log.info('PuppetHostie', `ding() Skip ding since grpcClient is not connected.`)
+      return;
+    }
+
+    this.grpcClient.ding(
       request,
       (error, _response) => {
         if (error) {


### PR DESCRIPTION
Sometimes the `discoverHostieIp` call takes too long to complete, so the `grpcClient` won't be initialized before we make the first `ding()` from `wechaty-puppet`. So it would be better to check the `grpcClient` existence before we actually do the `ding()` call to grpc layer.