### PR TITLE
add reconnect loop when no endpoint happened

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-hostie",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Puppet Hostie for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-hostie",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Puppet Hostie for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -198,7 +198,9 @@ export class PuppetHostie extends Puppet {
     if (!endpoint) {
       const { ip, port } = await this.discoverHostieIp(this.options.token!)
       if (!ip || ip === '0.0.0.0') {
-        throw new Error('no endpoint')
+        log.warn('No endpoint when starting grpc client, reconnecting in 10 seconds...')
+        await new Promise(resolve => setTimeout(resolve, 10 * 1000))
+        return this.startGrpcClient()
       }
       endpoint = ip + ':' + port
     }
@@ -432,7 +434,8 @@ export class PuppetHostie extends Puppet {
     log.verbose('PuppetHostie', 'stopGrpcStream()')
 
     if (!this.eventStream) {
-      throw new Error('no event stream')
+      log.verbose('PuppetHostie', 'no eventStream when stop, skip destroy.')
+      return
     }
 
     /**


### PR DESCRIPTION
This PR will add a retry recursion when the `no endpoint` error happened. 

This will improve the situation described in #39