### PR TITLE
refactor reconnect logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "shx": "^0.3.2",
     "tstest": "^0.4.10",
     "wechaty": "^0.46.4",
-    "wechaty-puppet": "^0.27.1",
+    "wechaty-puppet": "^0.31.0",
     "wechaty-puppet-mock": "^0.22.41"
   },
   "peerDependencies": {

--- a/src/client/recover$.ts
+++ b/src/client/recover$.ts
@@ -41,7 +41,7 @@ export const dingHeartbeat = (puppet: Puppet) => (n: number) => puppet.ding(`rec
  */
 export const switchOn$  = (puppet: Puppet) => fromEvent(puppet.state, 'on')
 export const switchOff$ = (puppet: Puppet) => fromEvent(puppet.state, 'off')
-export const heartbeat$ = (puppet: Puppet) => fromEvent<{}>(puppet, 'heartbeat')
+export const heartbeat$ = (puppet: Puppet) => fromEvent<{}>(puppet as any, 'heartbeat')
 
 /**
  * Streams

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -91,7 +91,7 @@ export function puppetImplementation (
   puppet.on('ready', payload => { readyPayload = payload  })
   puppet.on('login', _       => {
     scanPayload = undefined
-    setTimeout(() => readyPayload && eventStreamManager.grpcEmit(EventType.EVENT_TYPE_READY, readyPayload))
+    setTimeout(() => readyPayload && eventStreamManager.grpcEmit(EventType.EVENT_TYPE_READY, readyPayload), 5 * 1000)
   })
 
   const eventStreamManager = new EventStreamManager(puppet)


### PR DESCRIPTION
### Improve the reconnect logic based on https://github.com/wechaty/wechaty-puppet-hostie/pull/61#issuecomment-670643990

1. block start() when it retries (as you mentioned)
1. add a maximum retry time, and throw an error after running out of retry times.

---

Rely on https://github.com/wechaty/wechaty-puppet/pull/108, will always be failed before this PR get merged.