### PR TITLE
Add grpc.default_authority option for authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ WECHATY_PUPPET_HOSTIE_TOKEN=hostie_token node bot.js
 
 ### v0.10.4 (Oct 2020)
 
-1. Add 'grpc.default_authority' to gRPC client option.gRPC server can use the authority  to identify current user.
+1. Add 'grpc.default_authority' to gRPC client option.
+   gRPC server can use the authority  to identify current user.
 
 ### v0.6 (Apr 2020)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ WECHATY_PUPPET_HOSTIE_TOKEN=hostie_token node bot.js
 
 ### master
 
+### v0.10.4 (Oct 2020)
+
+1. Add 'grpc.default_authority' to gRPC client option.gRPC server can use the authority  to identify current user.
+
 ### v0.6 (Apr 2020)
 
 Beta Version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-hostie",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Puppet Hostie for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -222,7 +222,10 @@ export class PuppetHostie extends Puppet {
       endpoint = hostieIpResult.ip + ':' + hostieIpResult.port
     }
 
-    const clientOptions = Object.assign({}, GRPC_LIMITATION, { 'grpc.default_authority':this.options.token })
+    const clientOptions = {
+      ...GRPC_LIMITATION,
+      'grpc.default_authority': this.options.token,
+    }
     this.grpcClient = new PuppetClient(
       endpoint, // 'localhost:50051',
       grpc.credentials.createInsecure(),

--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -222,7 +222,7 @@ export class PuppetHostie extends Puppet {
       endpoint = hostieIpResult.ip + ':' + hostieIpResult.port
     }
 
-    const clientOptions = Object.assign({},GRPC_LIMITATION,{'grpc.default_authority':this.options.token})
+    const clientOptions = Object.assign({}, GRPC_LIMITATION, { 'grpc.default_authority':this.options.token })
     this.grpcClient = new PuppetClient(
       endpoint, // 'localhost:50051',
       grpc.credentials.createInsecure(),

--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -222,10 +222,11 @@ export class PuppetHostie extends Puppet {
       endpoint = hostieIpResult.ip + ':' + hostieIpResult.port
     }
 
+    const clientOptions = Object.assign({},GRPC_LIMITATION,{'grpc.default_authority':this.options.token})
     this.grpcClient = new PuppetClient(
       endpoint, // 'localhost:50051',
       grpc.credentials.createInsecure(),
-      GRPC_LIMITATION,
+      clientOptions
     )
   }
 


### PR DESCRIPTION
Some hostie server don't use different port for service,It can use the authority to identify user.