### PR TITLE
Fix response type bug

### DIFF
--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -118,6 +118,7 @@ import {
 import { EventDirtyPayload } from 'wechaty-puppet/dist/src/schemas/event'
 import { toMessageSendFileStreamRequest } from '../stream/message-send-file-stream-request'
 import { chunkStreamToFileBox } from '../stream/file-box-helper'
+import { unpackFileBoxChunk } from '../stream/file-box-packer'
 
 const MAX_HOSTIE_IP_DISCOVERY_RETRIES = 10
 const MAX_GRPC_CONNECTION_RETRIES = 5
@@ -842,8 +843,8 @@ export class PuppetHostie extends Puppet {
       throw new Error('Can not get image from message since no grpc client.')
     }
     const stream = this.grpcClient.messageImageStream(request)
-
-    return chunkStreamToFileBox(stream)
+    const fileBoxStream = unpackFileBoxChunk(stream)
+    return chunkStreamToFileBox(fileBoxStream)
   }
 
   public async messageContact (

--- a/src/client/puppet-hostie.ts
+++ b/src/client/puppet-hostie.ts
@@ -843,8 +843,8 @@ export class PuppetHostie extends Puppet {
       throw new Error('Can not get image from message since no grpc client.')
     }
     const stream = this.grpcClient.messageImageStream(request)
-    const fileBoxStream = unpackFileBoxChunk(stream)
-    return chunkStreamToFileBox(fileBoxStream)
+    const fileBoxChunkStream = unpackFileBoxChunk(stream)
+    return chunkStreamToFileBox(fileBoxChunkStream)
   }
 
   public async messageContact (
@@ -909,7 +909,8 @@ export class PuppetHostie extends Puppet {
       throw new Error('Can not get file from message since no grpc client.')
     }
     const stream = this.grpcClient.messageFileStream(request)
-    return chunkStreamToFileBox(stream)
+    const fileBoxChunkStream = unpackFileBoxChunk(stream)
+    return chunkStreamToFileBox(fileBoxChunkStream)
   }
 
   public async messageRawPayload (id: string): Promise<MessagePayload> {

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -58,6 +58,7 @@ import {
   ContactDescriptionResponse,
   ContactCorporationRemarkResponse,
   MessageSendFileStreamResponse,
+  MessageImageStreamResponse,
 }                                   from '@chatie/grpc'
 
 import {
@@ -79,6 +80,7 @@ import { grpcError } from './grpc-error'
 import { EventStreamManager }   from './event-stream-manager'
 import { toMessageSendFileStreamRequestArgs } from '../stream/message-send-file-stream-request'
 import { fileBoxToChunkStream } from '../stream/file-box-helper'
+import { packFileBoxChunk } from '../stream/file-box-packer'
 
 /**
  * Implements the SayHello RPC method.
@@ -603,7 +605,8 @@ export function puppetImplementation (
         const fileBox = await puppet.messageImage(id, type as number as ImageType)
 
         const stream = await fileBoxToChunkStream(fileBox)
-        stream.pipe(call)
+        const response = new MessageImageStreamResponse()
+        packFileBoxChunk(stream, response).pipe(call)
       } catch (e) {
         log.error('PuppetServiceImpl', 'grpcError() messageImageStream() rejection: %s', e && e.message)
         call.emit('error', e)

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -59,6 +59,7 @@ import {
   ContactCorporationRemarkResponse,
   MessageSendFileStreamResponse,
   MessageImageStreamResponse,
+  MessageFileStreamResponse,
 }                                   from '@chatie/grpc'
 
 import {
@@ -568,7 +569,8 @@ export function puppetImplementation (
         const fileBox = await puppet.messageFile(id)
 
         const stream = await fileBoxToChunkStream(fileBox)
-        stream.pipe(call)
+        const response = new MessageFileStreamResponse()
+        packFileBoxChunk(stream, response).pipe(call)
       } catch (e) {
         log.error('PuppetServiceImpl', 'grpcError() messageFileStream() rejection: %s', e && e.message)
         call.emit('error', e)

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -569,8 +569,7 @@ export function puppetImplementation (
         const fileBox = await puppet.messageFile(id)
 
         const stream = await fileBoxToChunkStream(fileBox)
-        const response = new MessageFileStreamResponse()
-        packFileBoxChunk(stream, response).pipe(call)
+        packFileBoxChunk(stream, MessageFileStreamResponse).pipe(call)
       } catch (e) {
         log.error('PuppetServiceImpl', 'grpcError() messageFileStream() rejection: %s', e && e.message)
         call.emit('error', e)
@@ -607,8 +606,7 @@ export function puppetImplementation (
         const fileBox = await puppet.messageImage(id, type as number as ImageType)
 
         const stream = await fileBoxToChunkStream(fileBox)
-        const response = new MessageImageStreamResponse()
-        packFileBoxChunk(stream, response).pipe(call)
+        packFileBoxChunk(stream, MessageImageStreamResponse).pipe(call)
       } catch (e) {
         log.error('PuppetServiceImpl', 'grpcError() messageImageStream() rejection: %s', e && e.message)
         call.emit('error', e)
@@ -734,7 +732,7 @@ export function puppetImplementation (
     },
 
     messageSendFileStream: async (call, callback) => {
-      log.verbose('PuppetServiceImpl', 'messageSendFile()')
+      log.verbose('PuppetServiceImpl', 'messageSendFileStream()')
 
       try {
         const requestArgs = await toMessageSendFileStreamRequestArgs(call)
@@ -754,7 +752,7 @@ export function puppetImplementation (
         return callback(null, response)
 
       } catch (e) {
-        return grpcError('messageSendFile', e, callback)
+        return grpcError('messageSendFileStream', e, callback)
       }
     },
 

--- a/src/stream/file-box-helper.ts
+++ b/src/stream/file-box-helper.ts
@@ -19,7 +19,8 @@ const decoder = () => new TypedTransform<FileBoxChunk, any>({
   objectMode: true,
   transform: (chunk: FileBoxChunk, _: any, callback: any) => {
     if (!chunk.hasData()) {
-      throw new Error('no data')
+      callback(new Error('no data'))
+      return
     }
     const data = chunk.getData()
     callback(null, data)

--- a/src/stream/file-box-packer.spec.ts
+++ b/src/stream/file-box-packer.spec.ts
@@ -1,0 +1,99 @@
+import test  from 'tstest'
+
+import { PassThrough } from 'stream'
+
+import { FileBox } from 'wechaty-puppet'
+
+import {
+  FileBoxChunk,
+  // FileBoxChunk,
+  MessageFileStreamResponse,
+  MessageSendFileStreamRequest,
+}                 from '@chatie/grpc'
+
+import {
+  packFileBoxChunk,
+  unpackFileBoxChunk,
+}                   from './file-box-packer'
+
+import { chunkStreamToFileBox, fileBoxToChunkStream } from './file-box-helper'
+
+test('packFileBoxChunk()', async t => {
+  const FILE_BOX_DATA = 'test'
+  const FILE_BOX_NAME = 'test.dat'
+
+  const fileBox = FileBox.fromBuffer(
+    Buffer.from(FILE_BOX_DATA),
+    FILE_BOX_NAME,
+  )
+
+  const chunkStream = await fileBoxToChunkStream(fileBox)
+
+  const message = new MessageFileStreamResponse()
+  const packedStream = packFileBoxChunk(chunkStream, message)
+
+  let name = ''
+  let buffer = ''
+  packedStream.on('data', (data: MessageFileStreamResponse) => {
+    if (data.hasFileBoxChunk()) {
+      const fileBoxChunk = data.getFileBoxChunk()
+      if (fileBoxChunk!.hasData()) {
+        buffer += fileBoxChunk!.getData()
+      } else if (fileBoxChunk!.hasName()) {
+        name = fileBoxChunk!.getName()
+      }
+    }
+  })
+
+  await new Promise(resolve => packedStream.on('end', resolve))
+  t.equal(name, FILE_BOX_NAME, 'should get file box name')
+  t.equal(buffer, FILE_BOX_DATA, 'should get file box data')
+
+})
+
+test('unpackFileBoxChunk()', async t => {
+  const FILE_BOX_DATA = 'test'
+  const FILE_BOX_NAME = 'test.dat'
+
+  const fileBox = FileBox.fromBuffer(
+    Buffer.from(FILE_BOX_DATA),
+    FILE_BOX_NAME,
+  )
+
+  const chunkStream = await fileBoxToChunkStream(fileBox)
+  const request = new MessageSendFileStreamRequest()
+
+  const packedStream = new PassThrough({ objectMode: true })
+
+  chunkStream.on('data', (data: FileBoxChunk) => {
+    request.setFileBoxChunk(data)
+    packedStream.write(request)
+  }).on('end', () => {
+    packedStream.end()
+  })
+
+  const outputChunkStream = unpackFileBoxChunk(packedStream)
+
+  const outputFileBox = await chunkStreamToFileBox(outputChunkStream)
+  t.equal((await outputFileBox.toBuffer()).toString(), FILE_BOX_DATA, 'should get file box data')
+})
+
+test('packFileBoxChunk() <-> unpackFileBoxChunk()', async t => {
+  const FILE_BOX_DATA = 'test'
+  const FILE_BOX_NAME = 'test.dat'
+
+  const fileBox = FileBox.fromBuffer(
+    Buffer.from(FILE_BOX_DATA),
+    FILE_BOX_NAME,
+  )
+
+  const stream = await fileBoxToChunkStream(fileBox)
+  const response = new MessageFileStreamResponse()
+  const packedStream = packFileBoxChunk(stream, response)
+
+  const unpackedStream = unpackFileBoxChunk(packedStream)
+  const restoredBox = await chunkStreamToFileBox(unpackedStream)
+
+  t.equal(fileBox.name, restoredBox.name, 'should be same name')
+  t.equal(await fileBox.toBase64(), await restoredBox.toBase64(), 'should be same content')
+})

--- a/src/stream/file-box-packer.spec.ts
+++ b/src/stream/file-box-packer.spec.ts
@@ -29,8 +29,7 @@ test('packFileBoxChunk()', async t => {
 
   const chunkStream = await fileBoxToChunkStream(fileBox)
 
-  const message = new MessageFileStreamResponse()
-  const packedStream = packFileBoxChunk(chunkStream, message)
+  const packedStream = packFileBoxChunk(chunkStream, MessageFileStreamResponse)
 
   let name = ''
   let buffer = ''
@@ -88,8 +87,7 @@ test('packFileBoxChunk() <-> unpackFileBoxChunk()', async t => {
   )
 
   const stream = await fileBoxToChunkStream(fileBox)
-  const response = new MessageFileStreamResponse()
-  const packedStream = packFileBoxChunk(stream, response)
+  const packedStream = packFileBoxChunk(stream, MessageFileStreamResponse)
 
   const unpackedStream = unpackFileBoxChunk(packedStream)
   const restoredBox = await chunkStreamToFileBox(unpackedStream)

--- a/src/stream/file-box-packer.ts
+++ b/src/stream/file-box-packer.ts
@@ -8,7 +8,7 @@ import {
 }                   from './typed-stream'
 
 const encoder = <T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }>(
-  message: T
+  message: T,
 ) => new TypedTransform<FileBoxChunk, T>({
   objectMode: true,
   transform: (chunk: FileBoxChunk, _: any, callback: (error: Error | null, data: T) => void) => {
@@ -19,12 +19,26 @@ const encoder = <T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }>(
 
 function packFileBoxChunk<T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }> (
   stream: Readable<FileBoxChunk>,
-  predefinedMessage: T
+  predefinedMessage: T,
 ): Readable<T> {
   const outStream = stream.pipe(encoder(predefinedMessage))
   return outStream
 }
 
+function unpackFileBoxChunk<T extends { getFileBoxChunk: () => FileBoxChunk}> (
+  stream: Readable<T>,
+): Readable<FileBoxChunk> {
+  return stream.pipe(decoder())
+}
+
+const decoder = <T extends { getFileBoxChunk: () => FileBoxChunk }>() => new TypedTransform<T, FileBoxChunk>({
+  objectMode: true,
+  transform: (chunk: T, _: any, callback: (error: Error | null, data: FileBoxChunk) => void) => {
+    callback(null, chunk.getFileBoxChunk())
+  },
+})
+
 export {
   packFileBoxChunk,
+  unpackFileBoxChunk,
 }

--- a/src/stream/file-box-packer.ts
+++ b/src/stream/file-box-packer.ts
@@ -1,0 +1,30 @@
+import {
+  FileBoxChunk,
+}                 from '@chatie/grpc'
+
+import {
+  Readable,
+  TypedTransform,
+}                   from './typed-stream'
+
+const encoder = <T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }>(
+  message: T
+) => new TypedTransform<FileBoxChunk, T>({
+  objectMode: true,
+  transform: (chunk: FileBoxChunk, _: any, callback: (error: Error | null, data: T) => void) => {
+    message.setFileBoxChunk(chunk)
+    callback(null, message)
+  },
+})
+
+function packFileBoxChunk<T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }> (
+  stream: Readable<FileBoxChunk>,
+  predefinedMessage: T
+): Readable<T> {
+  const outStream = stream.pipe(encoder(predefinedMessage))
+  return outStream
+}
+
+export {
+  packFileBoxChunk,
+}

--- a/src/stream/file-box-packer.ts
+++ b/src/stream/file-box-packer.ts
@@ -25,16 +25,21 @@ function packFileBoxChunk<T extends { setFileBoxChunk: (chunk: FileBoxChunk) => 
   return outStream
 }
 
-function unpackFileBoxChunk<T extends { getFileBoxChunk: () => FileBoxChunk}> (
+function unpackFileBoxChunk<T extends { getFileBoxChunk: () => FileBoxChunk | undefined }> (
   stream: Readable<T>,
 ): Readable<FileBoxChunk> {
   return stream.pipe(decoder())
 }
 
-const decoder = <T extends { getFileBoxChunk: () => FileBoxChunk }>() => new TypedTransform<T, FileBoxChunk>({
+const decoder = <T extends { getFileBoxChunk: () => FileBoxChunk | undefined }>() => new TypedTransform<T, FileBoxChunk>({
   objectMode: true,
-  transform: (chunk: T, _: any, callback: (error: Error | null, data: FileBoxChunk) => void) => {
-    callback(null, chunk.getFileBoxChunk())
+  transform: (chunk: T, _: any, callback: (error: Error | null, data?: FileBoxChunk) => void) => {
+    const fileBoxChunk = chunk.getFileBoxChunk()
+    if (!fileBoxChunk) {
+      callback(new Error('No FileBoxChunk'))
+    } else {
+      callback(null, fileBoxChunk)
+    }
   },
 })
 

--- a/src/stream/file-box-packer.ts
+++ b/src/stream/file-box-packer.ts
@@ -8,10 +8,11 @@ import {
 }                   from './typed-stream'
 
 const encoder = <T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }>(
-  message: T,
+  Data: { new(): T },
 ) => new TypedTransform<FileBoxChunk, T>({
   objectMode: true,
   transform: (chunk: FileBoxChunk, _: any, callback: (error: Error | null, data: T) => void) => {
+    const message = new Data()
     message.setFileBoxChunk(chunk)
     callback(null, message)
   },
@@ -19,10 +20,9 @@ const encoder = <T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }>(
 
 function packFileBoxChunk<T extends { setFileBoxChunk: (chunk: FileBoxChunk) => void }> (
   stream: Readable<FileBoxChunk>,
-  predefinedMessage: T,
+  DataConstructor: { new(): T },
 ): Readable<T> {
-  const outStream = stream.pipe(encoder(predefinedMessage))
-  return outStream
+  return stream.pipe(encoder(DataConstructor))
 }
 
 function unpackFileBoxChunk<T extends { getFileBoxChunk: () => FileBoxChunk | undefined }> (

--- a/src/stream/first-data.ts
+++ b/src/stream/first-data.ts
@@ -2,7 +2,11 @@ import {
   Readable,
 }           from './typed-stream'
 
-const TIMEOUT = 10 * 1000
+/**
+ * windmemory(20201027): generating fileBox data in server side might take longer.
+ * Set to 60 sec to avoid unexpected timeout.
+ */
+const TIMEOUT = 60 * 1000
 
 async function firstData<T> (
   stream: Readable<T>

--- a/src/stream/message-send-file-stream-request.ts
+++ b/src/stream/message-send-file-stream-request.ts
@@ -1,5 +1,4 @@
 import {
-  FileBoxChunk,
   MessageSendFileStreamRequest,
 }                                     from '@chatie/grpc'
 import { FileBox } from 'wechaty-puppet'
@@ -7,32 +6,18 @@ import { PassThrough } from 'stream'
 
 import {
   Readable,
-  TypedTransform,
 }                   from './typed-stream'
 import { firstData } from './first-data'
 import {
   chunkStreamToFileBox,
   fileBoxToChunkStream,
 }                   from './file-box-helper'
+import { packFileBoxChunk, unpackFileBoxChunk } from './file-box-packer'
 
 interface MessageSendFileStreamRequestArgs {
   conversationId: string,
   fileBox: FileBox,
 }
-
-const decoder = () => new TypedTransform<
-  MessageSendFileStreamRequest,
-  FileBoxChunk
->({
-  objectMode: true,
-  transform: (chunk: MessageSendFileStreamRequest, _: any, callback: any) => {
-    if (!chunk.hasFileBoxChunk()) {
-      throw new Error('no file box chunk')
-    }
-    const fileBoxChunk = chunk.getFileBoxChunk()
-    callback(null, fileBoxChunk)
-  },
-})
 
 async function toMessageSendFileStreamRequestArgs (
   stream: Readable<MessageSendFileStreamRequest>
@@ -43,26 +28,13 @@ async function toMessageSendFileStreamRequestArgs (
   }
   const conversationId = chunk.getConversationId()
 
-  const fileBoxChunkStream = stream.pipe(decoder())
-  const fileBox = await chunkStreamToFileBox(fileBoxChunkStream)
+  const fileBox = await chunkStreamToFileBox(unpackFileBoxChunk(stream))
 
   return {
     conversationId,
     fileBox,
   }
 }
-
-const encoder = () => new TypedTransform<
-  FileBoxChunk,
-  MessageSendFileStreamRequest
->({
-  objectMode: true,
-  transform: (chunk: FileBoxChunk, _: any, callback: any) => {
-    const req = new MessageSendFileStreamRequest()
-    req.setFileBoxChunk(chunk)
-    callback(null, req)
-  },
-})
 
 async function toMessageSendFileStreamRequest (
   conversationId: string,
@@ -75,8 +47,9 @@ async function toMessageSendFileStreamRequest (
   stream.write(req)
 
   const fileBoxChunkStream = await fileBoxToChunkStream(fileBox)
-  fileBoxChunkStream
-    .pipe(encoder())
+  req.clearConversationId()
+
+  packFileBoxChunk(fileBoxChunkStream, req)
     .pipe(stream)
 
   return stream

--- a/src/stream/message-send-file-stream-request.ts
+++ b/src/stream/message-send-file-stream-request.ts
@@ -42,14 +42,13 @@ async function toMessageSendFileStreamRequest (
 ): Promise<Readable<MessageSendFileStreamRequest>> {
   const stream = new PassThrough({ objectMode: true })
 
-  const req = new MessageSendFileStreamRequest()
-  req.setConversationId(conversationId)
-  stream.write(req)
+  const first = new MessageSendFileStreamRequest()
+  first.setConversationId(conversationId)
+  stream.write(first)
 
   const fileBoxChunkStream = await fileBoxToChunkStream(fileBox)
-  req.clearConversationId()
 
-  packFileBoxChunk(fileBoxChunkStream, req)
+  packFileBoxChunk(fileBoxChunkStream, MessageSendFileStreamRequest)
     .pipe(stream)
 
   return stream


### PR DESCRIPTION
The [last PR](https://github.com/wechaty/wechaty-puppet-hostie/pull/84) was in WIP, and I did more test today with that version, and I found that the message send along the grpc is not the type that defined in the proto, it was `FileBoxChunk`, which should be wrapped into the request/response message.

So I created two new helper function that wrap the `FileBoxChunk` message into the request/response message class, unwrap the request/response message to `FileBoxChunk`. These two functions are fully defined with typings, and also covered by tests.